### PR TITLE
hard coding of UTF-8 as export format for plain text

### DIFF
--- a/source/exports.py
+++ b/source/exports.py
@@ -582,7 +582,7 @@ class ExportControl:
                     lines.extend(spot.nodeRef.output(True, False, spot))
                     if spot.nodeRef.formatRef.spaceBetween:
                         lines.append('')
-        with pathObj.open('w', encoding=globalref.localTextEncoding) as f:
+        with pathObj.open('w', encoding='utf-8') as f:
             f.writelines([(line + '\n') for line in lines])
         return True
 


### PR DESCRIPTION
Problem: The native encoding of treeline seems to be utf-8. If the OS encoding is set differently (for what ever reason this is common in Windows) plain text export is not possible as there exists no transcoding function instead the export will fail. 

So as long as no transcoding is done, hard coding the plain text export to utf-8 seems like a sensible solution, which is also used for treeline, xml, html  exports.