### PR TITLE
add word count equation

### DIFF
--- a/source/configdialog.py
+++ b/source/configdialog.py
@@ -2173,7 +2173,8 @@ _arithmeticOperators = [('+', _('add')),
                         ('degrees()', _('radians to degrees')),
                         ('radians()', _('degrees to radians')),
                         ('pi', _('pi constant')),
-                        ('e', _('natural log constant'))]
+                        ('e', _('natural log constant')),
+                        ('count()', _('number of words in arg'))]
 _comparisonOperators = [('==', _('equal to')),
                         ('<', _('less than')),
                         ('>', _('greater than')),
@@ -2194,8 +2195,7 @@ _textOperators = [('+', _('concatenate text')),
                   ("join(' ', )", _('join text using 1st arg as separator')),
                   ('upper()', _('convert text to upper case')),
                   ('lower()', _('convert text to lower case')),
-                  ('replace()', _('in 1st arg, replace 2nd arg with 3rd arg')),
-                  ('count()', _('number of words in arg'))]
+                  ('replace()', _('in 1st arg, replace 2nd arg with 3rd arg'))]
 # _operatorLists correspond to _operatorTypes
 _operatorLists = [_arithmeticOperators, _comparisonOperators, _textOperators]
 

--- a/source/configdialog.py
+++ b/source/configdialog.py
@@ -2194,7 +2194,8 @@ _textOperators = [('+', _('concatenate text')),
                   ("join(' ', )", _('join text using 1st arg as separator')),
                   ('upper()', _('convert text to upper case')),
                   ('lower()', _('convert text to lower case')),
-                  ('replace()', _('in 1st arg, replace 2nd arg with 3rd arg'))]
+                  ('replace()', _('in 1st arg, replace 2nd arg with 3rd arg')),
+                  ('count()', _('number of words in arg'))]
 # _operatorLists correspond to _operatorTypes
 _operatorLists = [_arithmeticOperators, _comparisonOperators, _textOperators]
 

--- a/source/matheval.py
+++ b/source/matheval.py
@@ -159,6 +159,14 @@ def replace(text, oldText, newText):
     """
     return str(text).replace(str(oldText), str(newText))
 
+def count(text):
+    """Added text function to count words.
+
+    Arguments:
+        text -- the string to analyze
+    """
+    return len(re.findall(r'\w+', str(text)))
+
 
 _fieldSplitRe = re.compile(r'{\*(\*|\$|&|#|\b)([\w_\-.]+)\*}')
 
@@ -562,7 +570,8 @@ allowedFunctions = set(['abs', 'float', 'int', 'len', 'max', 'min', 'pow',
                         'acos', 'asin', 'atan', 'cos', 'sin', 'tan', 'hypot',
                         'degrees', 'radians', 'pi', 'e',
                         'startswith', 'endswith', 'contains',
-                        'join', 'upper', 'lower', 'replace'])
+                        'join', 'upper', 'lower', 'replace',
+                        'count'])
 
 allowedNodeTypes = set(['Module', 'Expr', 'Name', 'NameConstant', 'Constant',
                         'Load', 'IfExp', 'Compare', 'Num', 'Str', 'Tuple',


### PR DESCRIPTION
For longer text fields, e.g. writing sections of a book, having a word counter is useful, so I hacked this together.

Usage in a Math-type field, with the name of `Words`:

`count({*Text*}) + sum({*&Words*})`

This will give the count of words in the current node's `Text` field added to all its child nodes' word counts. This can then be shown in the treeview headers and/or the output, as well as visible in the Data Edit view.

Could probably be dressed up a bit with a better RE? Don't know, but open to ideas and feedback. Would love to see this feature in the main release.

