### PR TITLE
Improvements for readability of the HTML export

### DIFF
--- a/templates/exports/live_tree_export.css
+++ b/templates/exports/live_tree_export.css
@@ -3,6 +3,7 @@
 body {
     background-color: white;
     color: black;
+    line-height: 1.4;
 }
 
 #tree {
@@ -33,7 +34,7 @@ body {
 }
 
 .selected {
-    color: red;
+    color: #b22222;
 }
 
 #output {


### PR DESCRIPTION
Thank you for creating TreeLine - I've instantly fallen in love with it :smiley: 

In the HTML export, we can improve the readability of the text by setting `line-height: 1.4` on the body:

![150en_sample_it-documentation-lineheight](https://github.com/user-attachments/assets/f3843c1f-38ca-432d-9727-dc31d24b006e)

This PR proposes to do that, and also use a shade of red for the selection that's slightly easier on the eyes.